### PR TITLE
Update some of the core components so they can be called from test drivers

### DIFF
--- a/smoke/src/generator.rs
+++ b/smoke/src/generator.rs
@@ -299,7 +299,7 @@ where
                 break x;
             }
             if retry == 0 {
-                panic!(SuchThatRetryFailure)
+                std::panic::panic_any(SuchThatRetryFailure);
             } else {
                 retry -= 1;
             }

--- a/smoke/src/initonce.rs
+++ b/smoke/src/initonce.rs
@@ -1,8 +1,9 @@
 //! small utility to initialize a static variable only once with a function
 
 use core::cell::UnsafeCell;
+use core::hint::spin_loop;
 use core::mem::MaybeUninit;
-use core::sync::atomic::{spin_loop_hint, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 pub struct InitOnce<T> {
     status: AtomicUsize,
@@ -47,7 +48,7 @@ impl<T> InitOnce<T> {
         } else if status == STATUS_INITING {
             // wait to be done
             while self.status.load(Ordering::SeqCst) != STATUS_DONE {
-                spin_loop_hint()
+                spin_loop()
             }
         }
 

--- a/smoke/src/lib.rs
+++ b/smoke/src/lib.rs
@@ -14,12 +14,11 @@ pub mod generator;
 pub mod property;
 mod rand;
 mod run;
-mod ux;
+pub mod ux;
 
 mod initonce;
 
 pub use generator::Generator;
 pub use property::Property;
 pub use rand::{NumPrimitive, Seed, R};
-pub use run::{forall, run, Ensure, Testable};
-pub use ux::TestResults;
+pub use run::{forall, run, Context, Ensure, Testable};

--- a/smoke/src/lib.rs
+++ b/smoke/src/lib.rs
@@ -22,3 +22,4 @@ pub use generator::Generator;
 pub use property::Property;
 pub use rand::{NumPrimitive, Seed, R};
 pub use run::{forall, run, Ensure, Testable};
+pub use ux::TestResults;

--- a/smoke/src/rand.rs
+++ b/smoke/src/rand.rs
@@ -20,7 +20,7 @@ use core::num::{
 /// as test driven development
 ///
 /// All pseudo random generators need to be derived from this
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct Seed(u128);
 
 /// A pseudo random generator at a given time
@@ -37,8 +37,7 @@ impl Seed {
     /// Whilst this is not particularly random, we just need a little randomization
     /// not a full blown unguessable entropy. The quality of this randomness
     /// is not particularly important or interesting.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn generate() -> Self {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
         use std::time::SystemTime;
@@ -106,7 +105,7 @@ const MUL_FACTOR: u64 = 636_4136_2238_4679_3005;
 
 impl R {
     pub fn new() -> (Seed, Self) {
-        let seed = Seed::new();
+        let seed = Seed::generate();
         let r = Self::from_seed(seed);
         (seed, r)
     }

--- a/smoke/src/run.rs
+++ b/smoke/src/run.rs
@@ -91,10 +91,10 @@ pub struct Ensure<G: Generator, F> {
 }
 
 /// Any tests to run with a testing context
-pub trait Testable: Sized {
-    fn test(self, context: &Context) -> TestResults;
+pub trait Testable {
+    fn test(&self, context: &Context) -> TestResults;
 
-    fn run(self, context: &mut Context) {
+    fn run(&self, context: &mut Context) {
         let results = self.test(context);
         context.test_results.add_subtests(&results);
     }
@@ -107,7 +107,7 @@ where
     F: Fn(&T) -> P,
     T: fmt::Debug + 'static,
 {
-    fn test(self, context: &Context) -> TestResults {
+    fn test(&self, context: &Context) -> TestResults {
         let mut r = R::from_seed(context.seed);
 
         let nb_tests = 1000;
@@ -116,8 +116,8 @@ where
 
         let mut result = TestResults::new();
 
-        let generator = self.generator;
-        let property_closure = self.property_closure;
+        let generator = &self.generator;
+        let property_closure = &self.property_closure;
         for _ in 0..nb_tests {
             let mut test_rng = r.sub();
 

--- a/smoke/src/ux.rs
+++ b/smoke/src/ux.rs
@@ -122,7 +122,7 @@ pub enum TestRunStatus {
 }
 
 /// A more detailed status of a test run
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TestResults {
     /// Total inner tests
     pub nb_tests: usize,
@@ -152,14 +152,7 @@ impl TestResults {
     }
 
     pub fn new() -> Self {
-        TestResults {
-            nb_tests: 0,
-            nb_success: 0,
-            nb_failed: 0,
-            nb_skipped: 0,
-            failures: Vec::new(),
-            duration: Duration::new(0, 0),
-        }
+        Self::default()
     }
 
     pub fn add_success(&mut self) {


### PR DESCRIPTION
add some of functionalities to call the `Ensure` and the `Context` from outside of the `smoke` internals