### PR TITLE
Improve Range

### DIFF
--- a/smoke/src/generator/numerical.rs
+++ b/smoke/src/generator/numerical.rs
@@ -51,3 +51,82 @@ pub fn num<T: NumPrimitive>() -> Num<T> {
 pub fn range<T: NumPrimitive>(range: std::ops::Range<T>) -> NumRange<T> {
     NumRange::new(range)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn range_boundaries<T>(start: T, end: T)
+    where T: NumPrimitive + PartialOrd
+    {
+        let (_, mut r) = R::new();
+
+        let range = std::ops::Range::<T>{ start, end };
+        let num_range = super::range::<T>(range.clone());
+
+        for _ in 0..1024 {
+            let v = num_range.gen(&mut r);
+            assert!(range.contains(&v));
+        }
+    }
+
+    #[test]
+    fn i8_range() {
+        range_boundaries::<i8>(1, 16);
+    }
+
+    #[test]
+    fn u8_range() {
+        range_boundaries::<u8>(1, 16);
+    }
+
+    #[test]
+    fn i16_range() {
+        range_boundaries::<i16>(1, 16);
+    }
+
+    #[test]
+    fn u16_range() {
+        range_boundaries::<u16>(1, 16);
+    }
+
+    #[test]
+    fn i32_range() {
+        range_boundaries::<i32>(1, 16);
+    }
+
+    #[test]
+    fn u32_range() {
+        range_boundaries::<u32>(1, 16);
+    }
+
+    #[test]
+    fn i64_range() {
+        range_boundaries::<i64>(1, 16);
+    }
+
+    #[test]
+    fn u64_range() {
+        range_boundaries::<u64>(1, 16);
+    }
+
+    #[test]
+    fn i128_range() {
+        range_boundaries::<i128>(1, 16);
+    }
+
+    #[test]
+    fn u128_range() {
+        range_boundaries::<u128>(1, 16);
+    }
+
+    #[test]
+    fn isize_range() {
+        range_boundaries::<isize>(1, 16);
+    }
+
+    #[test]
+    fn usize_range() {
+        range_boundaries::<usize>(1, 16);
+    }
+}

--- a/smoke/src/generator/numerical.rs
+++ b/smoke/src/generator/numerical.rs
@@ -56,7 +56,7 @@ pub fn range<T: NumPrimitive>(range: std::ops::Range<T>) -> NumRange<T> {
 mod tests {
     use super::*;
 
-    fn range_boundaries<T>(start: T, end: T)
+    fn num_range<T>(start: T, end: T)
     where T: NumPrimitive + PartialOrd
     {
         let (_, mut r) = R::new();
@@ -71,62 +71,62 @@ mod tests {
     }
 
     #[test]
-    fn i8_range() {
-        range_boundaries::<i8>(1, 16);
+    fn i8_num_range() {
+        num_range::<i8>(1, 16);
     }
 
     #[test]
-    fn u8_range() {
-        range_boundaries::<u8>(1, 16);
+    fn u8_num_range() {
+        num_range::<u8>(1, 16);
     }
 
     #[test]
-    fn i16_range() {
-        range_boundaries::<i16>(1, 16);
+    fn i16_num_range() {
+        num_range::<i16>(1, 16);
     }
 
     #[test]
-    fn u16_range() {
-        range_boundaries::<u16>(1, 16);
+    fn u16_num_range() {
+        num_range::<u16>(1, 16);
     }
 
     #[test]
-    fn i32_range() {
-        range_boundaries::<i32>(1, 16);
+    fn i32_num_range() {
+        num_range::<i32>(1, 16);
     }
 
     #[test]
-    fn u32_range() {
-        range_boundaries::<u32>(1, 16);
+    fn u32_num_range() {
+        num_range::<u32>(1, 16);
     }
 
     #[test]
-    fn i64_range() {
-        range_boundaries::<i64>(1, 16);
+    fn i64_num_range() {
+        num_range::<i64>(1, 16);
     }
 
     #[test]
-    fn u64_range() {
-        range_boundaries::<u64>(1, 16);
+    fn u64_num_range() {
+        num_range::<u64>(1, 16);
     }
 
     #[test]
-    fn i128_range() {
-        range_boundaries::<i128>(1, 16);
+    fn i128_num_range() {
+        num_range::<i128>(1, 16);
     }
 
     #[test]
-    fn u128_range() {
-        range_boundaries::<u128>(1, 16);
+    fn u128_num_range() {
+        num_range::<u128>(1, 16);
     }
 
     #[test]
-    fn isize_range() {
-        range_boundaries::<isize>(1, 16);
+    fn isize_num_range() {
+        num_range::<isize>(1, 16);
     }
 
     #[test]
-    fn usize_range() {
-        range_boundaries::<usize>(1, 16);
+    fn usize_num_range() {
+        num_range::<usize>(1, 16);
     }
 }

--- a/smoke/src/rand.rs
+++ b/smoke/src/rand.rs
@@ -223,8 +223,8 @@ impl NumPrimitive for u8 {
         r.next() as u8
     }
     fn num_range(r: &mut R, min_value: Self, max_value: Self) -> Self {
-        assert!(min_value <= max_value);
-        let diff = max_value - min_value + 1;
+        assert!(min_value < max_value);
+        let diff = max_value - min_value;
         min_value + (r.next() as Self % diff)
     }
 }
@@ -235,8 +235,8 @@ impl NumPrimitive for u16 {
     }
 
     fn num_range(r: &mut R, min_value: Self, max_value: Self) -> Self {
-        assert!(min_value <= max_value);
-        let diff = max_value - min_value + 1;
+        assert!(min_value < max_value);
+        let diff = max_value - min_value;
         min_value + (r.next() as Self % diff)
     }
 }
@@ -246,8 +246,8 @@ impl NumPrimitive for u32 {
         r.next()
     }
     fn num_range(r: &mut R, min_value: Self, max_value: Self) -> Self {
-        assert!(min_value <= max_value);
-        let diff = max_value - min_value + 1;
+        assert!(min_value < max_value);
+        let diff = max_value - min_value;
         min_value + (u32::num(r) % diff)
     }
 }
@@ -259,8 +259,8 @@ impl NumPrimitive for u64 {
         v1 << 32 | v2
     }
     fn num_range(r: &mut R, min_value: Self, max_value: Self) -> Self {
-        assert!(min_value <= max_value);
-        let diff = max_value - min_value + 1;
+        assert!(min_value < max_value);
+        let diff = max_value - min_value;
         if diff > 0xffff_ffff {
             let v = Self::num(r) % diff;
             min_value + v
@@ -279,8 +279,8 @@ impl NumPrimitive for u128 {
         v1 << 96 | v2 << 64 | v3 << 32 | v4
     }
     fn num_range(r: &mut R, min_value: Self, max_value: Self) -> Self {
-        assert!(min_value <= max_value);
-        let diff = max_value - min_value + 1;
+        assert!(min_value < max_value);
+        let diff = max_value - min_value;
         if diff > 0xffff_ffff {
             let v = Self::num(r) % diff;
             min_value + v
@@ -301,8 +301,8 @@ impl NumPrimitive for usize {
         }
     }
     fn num_range(r: &mut R, min_value: Self, max_value: Self) -> Self {
-        assert!(min_value <= max_value);
-        let diff = max_value - min_value + 1;
+        assert!(min_value < max_value);
+        let diff = max_value - min_value;
         if diff > 0xffff_ffff {
             let v = Self::num(r) % diff;
             min_value + v
@@ -334,7 +334,6 @@ macro_rules! define_NumPrimitive_impl_signed {
                 <$unsigned_ty>::num(r) as $signed_ty
             }
             fn num_range(r: &mut R, min_value: Self, max_value: Self) -> Self {
-                assert!(min_value <= max_value);
                 <$unsigned_ty>::num_range(r, min_value as $unsigned_ty, max_value as $unsigned_ty)
                     as $signed_ty
             }


### PR DESCRIPTION
## Goal
Solve an issue related to the generation and ranges.
The ranges should be half-open (start <= x < end).

## 1 Commit 4ec3390
Added some tests for the generator::numerical::NumRanges.

## 2 Commit 2a9ed42
Solved the issue related with the ranges (half-open).

## 3 Commit 40f9933
Renamed the test names.