### PR TITLE
Range Bounds

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use smoke::generator::num;
+    use smoke::generator::{num, range_bounds};
     use smoke::property;
     use smoke_macros::smoketest;
+    use smoke::Property;
 
     #[smoketest{a: num::<u32>()}]
     fn test1(a: u32) {
@@ -12,5 +13,15 @@ mod tests {
     #[smoketest{a: num::<u32>(), b: num::<u32>() }]
     fn test2(a: u32, b: u32) {
         property::equal(a + b, b + a)
+    }
+
+    #[smoketest{r: range_bounds::<u8, std::ops::RangeInclusive<u8>>(20..=40)}]
+    fn test3(r: u32) {
+        property::less_equal(20, r).and(property::less_equal(r, 40))
+    }
+
+    #[smoketest{r: range_bounds(..20u32)}]
+    fn test4(r: u32) {
+        property::less(r, 20)
     }
 }

--- a/smoke/Cargo.toml
+++ b/smoke/Cargo.toml
@@ -13,6 +13,7 @@ description = "A framework for testing"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num-traits = "0.2"
 
 [features]
 default = []

--- a/smoke/src/generator/numerical.rs
+++ b/smoke/src/generator/numerical.rs
@@ -54,6 +54,14 @@ pub fn range<T: NumPrimitive>(range: std::ops::Range<T>) -> NumRange<T> {
     NumRange::new(range)
 }
 
+/// Generator for a simple numeric primitive using range expressions or
+/// range bounds
+pub fn range_bounds<T, U>(range: U) -> NumRangeBounds<T, U>
+where T: NumRangePrimitive,
+      U: RangeBounds<T>
+{
+    NumRangeBounds::new(range)
+}
 
 /// The NumRangeBounds is a generator that delivers numbers in the interval
 /// set by a range.
@@ -77,11 +85,11 @@ pub fn range<T: NumPrimitive>(range: std::ops::Range<T>) -> NumRange<T> {
 /// ```
 #[derive(Clone)]
 pub struct NumRangeBounds<T, U>(U, PhantomData<T>)
-where T: Sized,
+where T: NumRangePrimitive,
       U: RangeBounds<T>;
 
 impl<T, U> NumRangeBounds<T, U>
-where T: Sized,
+where T: NumRangePrimitive,
       U: RangeBounds<T>
 {
     pub fn new(range: U) -> Self {

--- a/smoke/src/generator/numerical.rs
+++ b/smoke/src/generator/numerical.rs
@@ -1,7 +1,9 @@
-use super::super::rand::{NumPrimitive, R};
+use super::super::rand::{NumPrimitive, NumRangePrimitive, R};
 /// Integer number generator for a numeric T (usize, u{8,16,32,64,128}, signed int, ..)
 use super::base::Generator;
 use core::marker::PhantomData;
+use std::ops::RangeBounds;
+use num_traits::cast::AsPrimitive;
 
 #[derive(Copy)]
 pub struct Num<T>(PhantomData<T>);
@@ -50,4 +52,119 @@ pub fn num<T: NumPrimitive>() -> Num<T> {
 /// Generator for a simple numeric primitive in a specific range
 pub fn range<T: NumPrimitive>(range: std::ops::Range<T>) -> NumRange<T> {
     NumRange::new(range)
+}
+
+#[derive(Clone)]
+pub struct NumRangeBounds<T, U>(U, PhantomData<T>)
+where T: Sized,
+      U: RangeBounds<T>;
+
+impl<T, U> NumRangeBounds<T, U>
+where T: Sized,
+      U: RangeBounds<T>
+{
+    pub fn new(range: U) -> Self {
+        NumRangeBounds(range, PhantomData)
+    }
+}
+
+impl<T, U> Generator for NumRangeBounds<T, U>
+where U: RangeBounds<T>,
+      T: NumRangePrimitive,
+      T: AsPrimitive<<T as NumRangePrimitive>::UnsignedType>,
+      u32: AsPrimitive<<T as NumRangePrimitive>::UnsignedType>
+{
+    type Item = T;
+
+    fn gen(&self, r: &mut R) -> T {
+        r.num_range_bounds(&self.0)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::NumRangePrimitive;
+
+    fn num_range_bounds<T>(range: impl RangeBounds<T> + Clone)
+    where T: NumRangePrimitive,
+          T: AsPrimitive<<T as NumRangePrimitive>::UnsignedType>,
+          u32: AsPrimitive<<T as NumRangePrimitive>::UnsignedType>
+    {
+        let (_, mut r) = R::new();
+        let num_range_bounds = NumRangeBounds::new(range.clone());
+
+        for _ in 0..1024 {
+            let v = num_range_bounds.gen(&mut r);
+            assert!(range.contains(&v));
+        }
+    }
+
+    #[test]
+    fn i8_range_bounds() {
+        num_range_bounds(1..=16i8);
+    }
+
+    #[test]
+    fn u8_range_bounds() {
+        num_range_bounds(std::ops::Range::<u8>{ start: 1, end: 16 });
+    }
+
+    #[test]
+    fn i16_range_bounds() {
+        num_range_bounds(std::ops::RangeFrom::<i16>{ start: 16 });
+    }
+
+    #[test]
+    fn u16_range_bounds() {
+        num_range_bounds(1u16..16);
+    }
+
+    #[test]
+    fn i32_range_bounds() {
+        num_range_bounds(std::ops::RangeTo::<i32>{ end: 16 });
+    }
+
+    #[test]
+    fn u32_range_bounds() {
+        num_range_bounds(1u32..=16);
+    }
+
+    #[test]
+    fn i64_range_bounds() {
+        num_range_bounds(1i64..16);
+    }
+
+    #[test]
+    fn u64_range_bounds() {
+        let (_, mut r) = R::new();
+        let num_range_bounds : NumRangeBounds<u64, std::ops::RangeFull> = NumRangeBounds::new(..);
+
+        for _ in 0..1024 {
+            let v = num_range_bounds.gen(&mut r);
+            assert!(v <= u64::MAX);
+            assert!(u64::MIN <= v);
+        }
+    }
+
+    #[test]
+    fn i128_range_bounds() {
+        num_range_bounds(1i128..16);
+    }
+
+    #[test]
+    fn u128_range_bounds() {
+        num_range_bounds(std::ops::RangeInclusive::<u128>::new(1, 16));
+    }
+
+    #[test]
+    fn isize_range_bounds() {
+        num_range_bounds(std::ops::RangeToInclusive::<isize>{ end: 16 });
+    }
+
+    #[test]
+    fn usize_range_bounds() {
+        num_range_bounds(1usize..16);
+    }
 }

--- a/smoke/src/generator/numerical.rs
+++ b/smoke/src/generator/numerical.rs
@@ -54,6 +54,27 @@ pub fn range<T: NumPrimitive>(range: std::ops::Range<T>) -> NumRange<T> {
     NumRange::new(range)
 }
 
+
+/// The NumRangeBounds is a generator that delivers numbers in the interval
+/// set by a range.
+/// It uses range expressions or the std::ops::RangeBounds interface as the
+/// input range.
+/// The range syntax are `..`, `a..`, `..b`, `..=c`, `d..e` or `f..=g`.
+///
+/// As sample code of the `NumRangeBounds`:
+/// ```rust
+/// use smoke::generator::NumRangeBounds;
+///
+/// let n : NumRangeBounds<u64, std::ops::RangeFull> = NumRangeBounds::new(..);
+///
+/// let n = NumRangeBounds::new(std::ops::RangeInclusive::<u128>::new(1, 20));
+///
+/// let n = NumRangeBounds::new(1u32..20);
+///
+/// let n = NumRangeBounds::new(1..=20u32);
+///
+/// let n = NumRangeBounds::new(1..20);
+/// ```
 #[derive(Clone)]
 pub struct NumRangeBounds<T, U>(U, PhantomData<T>)
 where T: Sized,


### PR DESCRIPTION
## Goal
Implement a range generator based on range expressions or range bounds.

## Description
* Use the range expressions (`..`, `a..`, `..b`, `..=c`, `d..e` or `f..=g`) or the RangeBounds (Range, RangeFrom, RangeTo, RangeFull, RangeInclusive or RangeToInclusive) as a input parameter for the smoketest.
* The PR only adds functionality that is why the current interface will not be affected by the changes.

## Samples
```rust
#[smoketest{r: range_bounds::<u8, std::ops::RangeInclusive<u8>>(20..=40)}]
fn test3(r: u32) {
    property::less_equal(20, r).and(property::less_equal(r, 40))
}

#[smoketest{r: range_bounds(..20u32)}]
fn test4(r: u32) {
    property::less(r, 20)
}
```
## Reference
* https://doc.rust-lang.org/std/ops/trait.RangeBounds.html
* https://doc.rust-lang.org/reference/expressions/range-expr.html

